### PR TITLE
Prevent drinks pouring a second time

### DIFF
--- a/bartender.py
+++ b/bartender.py
@@ -332,7 +332,9 @@ class Bartender(MenuDelegate):
 
 	def right_btn(self, ctx):
 		if not self.running:
+			self.stopInterrupts()
 			self.menuContext.select()
+		self.startInterrupts()
 
 	def updateProgressBar(self, percent, x=15, y=15):
 		height = 10

--- a/bartender.py
+++ b/bartender.py
@@ -334,7 +334,7 @@ class Bartender(MenuDelegate):
 		if not self.running:
 			self.stopInterrupts()
 			self.menuContext.select()
-		self.startInterrupts()
+			self.startInterrupts()
 
 	def updateProgressBar(self, percent, x=15, y=15):
 		height = 10


### PR DESCRIPTION
Fixes #1 
In our (_slightly_ modified) version of this code, we found that disabling interrupts _as soon as the button was pressed_ would prevent the bartender pouring 2 drinks consecutively without being prompted. Tested fairly thoroughly with both physical and remote (SSH) triggers.